### PR TITLE
Added Class Definition Flags

### DIFF
--- a/data/rules/char_class/class060_soulknife.py
+++ b/data/rules/char_class/class060_soulknife.py
@@ -5,7 +5,13 @@ import char_class_utils
 
 def GetConditionName(): # used by API
 	return "Soulknife"
-	
+
+def GetCategory():
+	return "Core 3.5 Ed Classes"
+
+def GetClassDefinitionFlags():
+	return CDF_BaseClass
+
 classEnum = stat_level_soulknife
 
 ###################################################


### PR DESCRIPTION
As of Temple+ 1.0.30, there's a new API call that gets Class Definition Flags (CDF_*).
Classes that are considered Base Classes require returning the CDF_BaseClass flag, which will cause them to be listed in the New Character Creation UI.