### PR TITLE
Added help topic to class definition API

### DIFF
--- a/data/rules/char_class/class060_soulknife.py
+++ b/data/rules/char_class/class060_soulknife.py
@@ -12,6 +12,9 @@ def GetCategory():
 def GetClassDefinitionFlags():
 	return CDF_BaseClass
 
+def GetClassHelpTopic():
+	return "TAG_SOUL_KNIVES"
+
 classEnum = stat_level_soulknife
 
 ###################################################


### PR DESCRIPTION
As of next version the class definition will also prove the help topic id (which will be looked up in help.tab or its extension files)